### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tokenizers==0.9.4
+tokenizers==0.9.3
 transformers==3.5.1
 tqdm
 git+https://bitbucket.org/eunjeon/mecab-python-0.996.git#egg=mecab-python


### PR DESCRIPTION
`transformers 3.5.1 requires tokenizers==0.9.3, but you'll have tokenizers 0.9.4 which is incompatible.` 다음의 에러를 수정하였습니다 :) 